### PR TITLE
Allow accessing groups in template

### DIFF
--- a/toscaparser/shell.py
+++ b/toscaparser/shell.py
@@ -101,6 +101,15 @@ class ParserShell(object):
                         print("\ttriggers:")
                         for trigger in policy.triggers:
                             print("\ttrigger name:" + trigger.name)'''
+        # groups
+        if hasattr(tosca, 'groups'):
+            groups = tosca.groups
+            if groups:
+                print("groups:")
+                for group in groups:
+                    print("\tgroup: " + group.name)
+                    for member in group.member_nodes:
+                        print("\t\tname: " + member.name)
 
         if hasattr(tosca, 'outputs'):
             outputs = tosca.outputs

--- a/toscaparser/tosca_template.py
+++ b/toscaparser/tosca_template.py
@@ -104,6 +104,7 @@ class ToscaTemplate(object):
                 self.inputs = self._inputs()
                 self.relationship_templates = self._relationship_templates()
                 self.nodetemplates = self._nodetemplates()
+                self.groups = self._groups()
                 self.outputs = self._outputs()
                 self.policies = self._policies()
                 self._handle_nested_tosca_templates_with_topology()
@@ -163,6 +164,9 @@ class ToscaTemplate(object):
 
     def _policies(self):
         return self.topology_template.policies
+    
+    def _groups(self):
+        return self.topology_template.groups
 
     def _get_all_custom_defs(self, imports=None):
         types = [IMPORTS, NODE_TYPES, CAPABILITY_TYPES, RELATIONSHIP_TYPES,


### PR DESCRIPTION
Parse and show groups, if they exist.

I tested with the following command:
`python tosca_parser.py --template-file=./toscaparser/tests/data/policies/tosca_policy_template.yaml`