### PR TITLE
Show policies after parsing

### DIFF
--- a/toscaparser/shell.py
+++ b/toscaparser/shell.py
@@ -91,7 +91,7 @@ class ParserShell(object):
                     print("\t" + node.name)
 
         # example of retrieving policy object
-        '''if hasattr(tosca, 'policies'):
+        if hasattr(tosca, 'policies'):
             policies = tosca.policies
             if policies:
                 print("policies:")
@@ -100,7 +100,7 @@ class ParserShell(object):
                     if policy.triggers:
                         print("\ttriggers:")
                         for trigger in policy.triggers:
-                            print("\ttrigger name:" + trigger.name)'''
+                            print("\t\tname:" + trigger.name)
 
         if hasattr(tosca, 'outputs'):
             outputs = tosca.outputs


### PR DESCRIPTION
Parse and show policies and its triggers, if they exist.

I tested with the following command:
`python tosca_parser.py --template-file=./toscaparser/tests/data/policies/tosca_policy_template.yaml`